### PR TITLE
chore: stop ignoring ralphai.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,5 +52,4 @@ bin/_chunks/
 bin/cli-wrapper.mjs
 bin/cli.d.mts
 
-
 .ralphai/

--- a/ralphai.json
+++ b/ralphai.json
@@ -1,0 +1,21 @@
+{
+  "agentCommand": "opencode run --agent build",
+  "feedbackCommands": [
+    "pnpm build",
+    "pnpm test",
+    "pnpm type-check",
+    "pnpm format:check"
+  ],
+  "baseBranch": "main",
+  "turns": 10,
+  "mode": "pr",
+  "autoCommit": false,
+  "turnTimeout": 0,
+  "promptMode": "auto",
+  "continuous": false,
+  "issueSource": "github",
+  "issueLabel": "ralphai",
+  "issueInProgressLabel": "ralphai:in-progress",
+  "issueRepo": "",
+  "issueCommentProgress": true
+}


### PR DESCRIPTION
## Summary
- Remove `ralphai.json` from `.gitignore` so it can be tracked in the repository.